### PR TITLE
New secure requests method

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The current release is distributed for Scala 2.11 or later. Add scalagram as a d
 Add the scalagram dependency:
 
 ```scala
-val scalagram = "com.github.Rydgel" %% "scalagram" % "0.1.5"
+val scalagram = "com.github.Rydgel" %% "scalagram" % "0.2.0"
 ```
 
 ## Run the test suite

--- a/README.md
+++ b/README.md
@@ -63,12 +63,13 @@ import scala.language.postfixOps
 
 val response: Response[List[Media]] = Await.result(Scalagram.userFeed(auth), 10 seconds)
 
-// Enforce signed headers
-// You can activate this option for some calls
-// (please read the documentation here http://instagram.com/developer/restrict-api-requests/)
-val headers = Authentication.createSignedHeader(clientSecret, Some(List("127.0.0.1")))
+// Enforce signed parameters
+// You can activate this option for all your calls
+// You just need to create a SignedAccessToken instead.
+// (please read the documentation here https://instagram.com/developer/secure-api-requests/)
+val signedAccessToken = SignedAccessToken(accessToken, clientSecret = secret)
 // Usage example
-Scalagram.comment(auth, "media-id", "my comment", Some(headers))
+Scalagram.comment(signedAccessToken, "media-id", "my comment")
 ```
 
 Please look at this file to see all availables methods: https://github.com/Rydgel/scalagram/blob/master/src/main/scala/com/rydgel/scalagram/Scalagram.scala

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ name := "scalagram"
 
 version := "0.2.0"
 
-scalaVersion := "2.11.5"
+scalaVersion := "2.11.7"
 
 scalacOptions += "-feature"
 
@@ -18,6 +18,7 @@ resolvers ++= Seq(
 libraryDependencies ++= Seq(
   "com.typesafe.play" %% "play-json" % "2.3.7",
   "net.databinder.dispatch" %% "dispatch-core" % "0.11.2",
+  "com.netaporter" %% "scala-uri" % "0.4.9",
   "org.scalatest" % "scalatest_2.11" % "2.2.1" % "test",
   "org.slf4j" % "slf4j-nop" % "1.6.4"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ sonatypeSettings
 
 name := "scalagram"
 
-version := "0.1.5"
+version := "0.2.0"
 
 scalaVersion := "2.11.5"
 

--- a/src/main/scala/com/rydgel/scalagram/Authentication.scala
+++ b/src/main/scala/com/rydgel/scalagram/Authentication.scala
@@ -25,6 +25,17 @@ object Authentication {
   }
 
   /**
+   * Tell if authentication type is secure.
+   *
+   * @param a Authentication
+   * @return  Boolean
+   */
+  def isSecure(a: Authentication): Boolean = a match {
+    case SignedAccessToken(_, _) => true
+    case _ => false
+  }
+
+  /**
    * Scope string which will be append to the URL.
    *
    * @param comments       Comments scope.
@@ -107,8 +118,8 @@ object Authentication {
    * @param params        Map of API parameters
    * @return String       Encoded header.
    */
-  def createSignedParam(clientSecret: String, endpoint: String, params: Map[String, String]): String = {
-    val paramsString = params.keys.toList.sorted.map(key => s"|$key=${params(key)}").mkString
+  def createSignedParam(clientSecret: String, endpoint: String, params: Map[String, Option[String]]): String = {
+    val paramsString = params.keys.toList.sorted.map(key => s"|$key=${params(key).mkString}").mkString
     val sig = s"$endpoint$paramsString"
     val secret = new SecretKeySpec(clientSecret.getBytes, "HmacSHA256")
     val mac = Mac.getInstance("HmacSHA256")

--- a/src/main/scala/com/rydgel/scalagram/Authentication.scala
+++ b/src/main/scala/com/rydgel/scalagram/Authentication.scala
@@ -21,6 +21,7 @@ object Authentication {
   def toGETParams(a: Authentication): String = a match {
     case ClientId(id) => s"client_id=$id"
     case AccessToken(token) => s"access_token=$token"
+    case SignedAccessToken(token, _) => s"access_token=$token"
   }
 
   /**
@@ -38,7 +39,7 @@ object Authentication {
       if (likes) "likes" else ""
     ).filter(_ != "")
 
-    if (scopes.headOption.isDefined) scopes.mkString("scope=", "+", "")
+    if (scopes.nonEmpty) scopes.mkString("scope=", "+", "")
     else ""
   }
 
@@ -73,13 +74,6 @@ object Authentication {
   }
 
   /**
-   * Get the local IP Address.
-   *
-   * @return String IP address.
-   */
-  private def localIpAddress(): String = InetAddress.getLocalHost.getHostAddress
-
-  /**
    * Converts an array of `bytes` to a hexadecimal representation String.
    * "Stolen" from the sbt source code.
    * Credits: http://www.scala-sbt.org/0.13.7/sxr/sbt/Hash.scala.html
@@ -89,7 +83,7 @@ object Authentication {
    */
   private def toHex(bytes: Array[Byte]): String = {
     val buffer = new StringBuilder(bytes.length * 2)
-    for (i <- 0 until bytes.length) {
+    for (i <- bytes.indices) {
       val b = bytes(i)
       val bi: Int = if (b < 0) b + 256 else b
       buffer append toHex((bi >>> 4).asInstanceOf[Byte])
@@ -100,10 +94,8 @@ object Authentication {
 
   private def toHex(b: Byte): Char = {
     require(b >= 0 && b <= 15, "Byte " + b + " was not between 0 and 15")
-    if (b < 10)
-      ('0'.asInstanceOf[Int] + b).asInstanceOf[Char]
-    else
-      ('a'.asInstanceOf[Int] + (b - 10)).asInstanceOf[Char]
+    if (b < 10) ('0'.asInstanceOf[Int] + b).asInstanceOf[Char]
+    else        ('a'.asInstanceOf[Int] + (b - 10)).asInstanceOf[Char]
   }
 
   /**
@@ -111,17 +103,18 @@ object Authentication {
    * http://instagram.com/developer/restrict-api-requests/
    *
    * @param clientSecret  Your Instagram client secret token.
-   * @param ips           Optional List of IP addresses.
+   * @param endpoint      API endpoint
+   * @param params        Map of API parameters
    * @return String       Encoded header.
    */
-  def createSignedHeader(clientSecret: String, ips: Option[List[String]]): String = {
-    val ipString = ips.getOrElse(List(localIpAddress())).mkString(",")
+  def createSignedParam(clientSecret: String, endpoint: String, params: Map[String, String]): String = {
+    val paramsString = params.keys.toList.sorted.map(key => s"|$key=${params(key)}").mkString
+    val sig = s"$endpoint$paramsString"
     val secret = new SecretKeySpec(clientSecret.getBytes, "HmacSHA256")
     val mac = Mac.getInstance("HmacSHA256")
     mac.init(secret)
-    val result = mac.doFinal(ipString.getBytes)
-    val resultString = toHex(result)
-    List(ipString, resultString).mkString("|")
+    val result = mac.doFinal(sig.getBytes)
+    toHex(result)
   }
 
   /**

--- a/src/main/scala/com/rydgel/scalagram/Scalagram.scala
+++ b/src/main/scala/com/rydgel/scalagram/Scalagram.scala
@@ -167,14 +167,12 @@ object Scalagram {
    * @param auth         Credentials.
    * @param userId       Instagram ID of the user.
    * @param action       Action (follow/unfollow/block/unblock/approve/deny).
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of a Relationship.
    */
-  private def updateRelationship(auth: Authentication, userId: String, action: String, signedHeader: Option[String] = None)
+  private def updateRelationship(auth: Authentication, userId: String, action: String)
   : Future[Response[Relationship]] = {
     val stringAuth = Authentication.toGETParams(auth)
-    val prepareRequest = url(s"https://api.instagram.com/v1/users/$userId/relationship?$stringAuth") << Map("action" -> action)
-    val request = addSignedHeader(prepareRequest, signedHeader)
+    val request = url(s"https://api.instagram.com/v1/users/$userId/relationship?$stringAuth") << Map("action" -> action)
     Request.send[Relationship](request)
   }
 
@@ -183,12 +181,11 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param userId       Instagram ID of the user.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of a Relationship.
    */
-  def relationshipFollow(auth: Authentication, userId: String, signedHeader: Option[String])
+  def relationshipFollow(auth: Authentication, userId: String)
   : Future[Response[Relationship]] = {
-    updateRelationship(auth, userId, action = "follow", signedHeader)
+    updateRelationship(auth, userId, action = "follow")
   }
 
   /**
@@ -196,12 +193,11 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param userId       Instagram ID of the user.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of a Relationship.
    */
-  def relationshipUnfollow(auth: Authentication, userId: String, signedHeader: Option[String])
+  def relationshipUnfollow(auth: Authentication, userId: String)
   : Future[Response[Relationship]] = {
-    updateRelationship(auth, userId, action = "unfollow", signedHeader)
+    updateRelationship(auth, userId, action = "unfollow")
   }
 
   /**
@@ -209,12 +205,11 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param userId       Instagram ID of the user.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of a Relationship.
    */
-  def relationshipBlock(auth: Authentication, userId: String, signedHeader: Option[String])
+  def relationshipBlock(auth: Authentication, userId: String)
   : Future[Response[Relationship]] = {
-    updateRelationship(auth, userId, action = "block", signedHeader)
+    updateRelationship(auth, userId, action = "block")
   }
 
   /**
@@ -222,12 +217,11 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param userId       Instagram ID of the user.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of a Relationship.
    */
-  def relationshipUnblock(auth: Authentication, userId: String, signedHeader: Option[String])
+  def relationshipUnblock(auth: Authentication, userId: String)
   : Future[Response[Relationship]] = {
-    updateRelationship(auth, userId, action = "unblock", signedHeader)
+    updateRelationship(auth, userId, action = "unblock")
   }
 
   /**
@@ -235,12 +229,11 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param userId       Instagram ID of the user.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of a Relationship.
    */
-  def relationshipApprove(auth: Authentication, userId: String, signedHeader: Option[String])
+  def relationshipApprove(auth: Authentication, userId: String)
   : Future[Response[Relationship]] = {
-    updateRelationship(auth, userId, action = "approve", signedHeader)
+    updateRelationship(auth, userId, action = "approve")
   }
 
   /**
@@ -248,12 +241,11 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param userId       Instagram ID of the user.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of a Relationship.
    */
-  def relationshipIgnore(auth: Authentication, userId: String, signedHeader: Option[String])
+  def relationshipIgnore(auth: Authentication, userId: String)
   : Future[Response[Relationship]] = {
-    updateRelationship(auth, userId, action = "ignore", signedHeader)
+    updateRelationship(auth, userId, action = "ignore")
   }
 
   /**
@@ -340,14 +332,12 @@ object Scalagram {
    * @param mediaId      Id-number of media object.
    * @param comment      The actual comment. See http://instagram.com/developer/endpoints/comments/#post_media_comments
    *                     for the list of restrictions (anti-spam).
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of Option[String].
    */
-  def comment(auth: Authentication, mediaId: String, comment: String, signedHeader: Option[String] = None)
+  def comment(auth: Authentication, mediaId: String, comment: String)
   : Future[Response[Option[String]]] = {
     val stringAuth = Authentication.toGETParams(auth)
-    val prepareRequest = url(s"https://api.instagram.com/v1/media/$mediaId/comments?$stringAuth") << Map("text" -> comment)
-    val request = addSignedHeader(prepareRequest, signedHeader)
+    val request = url(s"https://api.instagram.com/v1/media/$mediaId/comments?$stringAuth") << Map("text" -> comment)
     Request.send[Option[String]](request)
   }
 
@@ -357,14 +347,12 @@ object Scalagram {
    * @param auth         Credentials.
    * @param mediaId      Id-number of media object.
    * @param commentId    Id-number of the comment.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of Option[String].
    */
-  def commentDelete(auth: Authentication, mediaId: String, commentId: String, signedHeader: Option[String] = None)
+  def commentDelete(auth: Authentication, mediaId: String, commentId: String)
   : Future[Response[Option[String]]] = {
     val stringAuth = Authentication.toGETParams(auth)
-    val prepareRequest = url(s"https://api.instagram.com/v1/media/$mediaId/comments/$commentId/?$stringAuth").DELETE
-    val request = addSignedHeader(prepareRequest, signedHeader)
+    val request = url(s"https://api.instagram.com/v1/media/$mediaId/comments/$commentId/?$stringAuth").DELETE
     Request.send[Option[String]](request)
   }
 
@@ -386,14 +374,12 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param mediaId      Id-number of media object.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of Option[String].
    */
-  def like(auth: Authentication, mediaId: String, signedHeader: Option[String] = None)
+  def like(auth: Authentication, mediaId: String)
   : Future[Response[Option[String]]] = {
     val stringAuth = Authentication.toGETParams(auth)
-    val prepareRequest = url(s"https://api.instagram.com/v1/media/$mediaId/likes?$stringAuth").POST
-    val request = addSignedHeader(prepareRequest, signedHeader)
+    val request = url(s"https://api.instagram.com/v1/media/$mediaId/likes?$stringAuth").POST
     Request.send[Option[String]](request)
   }
 
@@ -402,14 +388,12 @@ object Scalagram {
    *
    * @param auth         Credentials.
    * @param mediaId      Id-number of media object.
-   * @param signedHeader An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
    * @return             A Future of a Response of Option[String].
    */
-  def unlike(auth: Authentication, mediaId: String, signedHeader: Option[String] = None)
+  def unlike(auth: Authentication, mediaId: String)
   : Future[Response[Option[String]]] = {
     val stringAuth = Authentication.toGETParams(auth)
-    val prepareRequest = url(s"https://api.instagram.com/v1/media/$mediaId/likes?$stringAuth").DELETE
-    val request = addSignedHeader(prepareRequest, signedHeader)
+    val request = url(s"https://api.instagram.com/v1/media/$mediaId/likes?$stringAuth").DELETE
     Request.send[Option[String]](request)
   }
 
@@ -521,18 +505,6 @@ object Scalagram {
       s"&foursquare_v2_id=${foursquareV2Id.mkString}$latitudeLongitude"
     )
     Request.send[List[LocationSearch]](request)
-  }
-
-  /**
-   * Add the signed header to the request.
-   *
-   * @param prepareRequest Prepared dispatch request
-   * @param signedHeader   An optional signed header. See: http://instagram.com/developer/restrict-api-requests/
-   * @return               A dispatch Req
-   */
-  private def addSignedHeader(prepareRequest: Req, signedHeader: Option[String] = None): Req = {
-    if (signedHeader.isDefined) prepareRequest <:< Map("X-Insta-Forwarded-For" -> signedHeader.get)
-    else prepareRequest
   }
 
 }

--- a/src/main/scala/com/rydgel/scalagram/responses/Authentication.scala
+++ b/src/main/scala/com/rydgel/scalagram/responses/Authentication.scala
@@ -3,3 +3,4 @@ package com.rydgel.scalagram.responses
 sealed trait Authentication
 case class ClientId(id: String) extends Authentication
 case class AccessToken(token: String) extends Authentication
+case class SignedAccessToken(token: String, clientSecret: String) extends Authentication

--- a/src/test/scala/com/rydgel/scalagram/AuthenticationSpec.scala
+++ b/src/test/scala/com/rydgel/scalagram/AuthenticationSpec.scala
@@ -47,8 +47,8 @@ class AuthenticationSpec extends FlatSpec with Matchers {
     val secret = "6dc1787668c64c939929c17683d7cb74"
     val endpoint = "/media/657988443280050001_25025320"
     val params = Map(
-      "access_token" -> "fb2e77d.47a0479900504cb3ab4a1f626d174d2d",
-      "count" -> "10"
+      "access_token" -> Some("fb2e77d.47a0479900504cb3ab4a1f626d174d2d"),
+      "count" -> Some("10")
     )
     Authentication.createSignedParam(secret, endpoint, params) should be (
       "260634b241a6cfef5e4644c205fb30246ff637591142781b86e2075faf1b163a"

--- a/src/test/scala/com/rydgel/scalagram/AuthenticationSpec.scala
+++ b/src/test/scala/com/rydgel/scalagram/AuthenticationSpec.scala
@@ -43,11 +43,15 @@ class AuthenticationSpec extends FlatSpec with Matchers {
     )
   }
 
-  "createSignedHeader" should "return a signed header for Instagram" in {
-    val clientSecret = "my-secret"
-    val ips = List("127.0.0.1")
-    Authentication.createSignedHeader(clientSecret, Some(ips)) should be (
-      "127.0.0.1|65f861cacea7dd9763d1623da913043a0226fc5f2decb1f937f3d2beb6f8cc43"
+  "createSignedParam" should "return a signed param for Instagram" in {
+    val secret = "6dc1787668c64c939929c17683d7cb74"
+    val endpoint = "/media/657988443280050001_25025320"
+    val params = Map(
+      "access_token" -> "fb2e77d.47a0479900504cb3ab4a1f626d174d2d",
+      "count" -> "10"
+    )
+    Authentication.createSignedParam(secret, endpoint, params) should be (
+      "260634b241a6cfef5e4644c205fb30246ff637591142781b86e2075faf1b163a"
     )
   }
 


### PR DESCRIPTION
Implementing the new method of signing Instagram request.
The old one is deprecated and have been removed, keep version **0.1.5** if you still need it.

More informations here: https://instagram.com/developer/secure-api-requests/
